### PR TITLE
fix: use the account State field instead of the deprecated Status

### DIFF
--- a/internal/aws/organizations.go
+++ b/internal/aws/organizations.go
@@ -8,6 +8,7 @@ import (
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -63,7 +64,7 @@ func (c *organizationsClient) listActiveAccounts(ctx context.Context) ([]Account
 		}
 
 		for _, acc := range page.Accounts {
-			if string(acc.Status) != "ACTIVE" {
+			if acc.State != types.AccountStateActive {
 				continue
 			}
 			accounts = append(accounts, Account{ID: *acc.Id, Name: *acc.Name})


### PR DESCRIPTION
AWS Organizations is retiring Status on 2026-09-09 in favor of the richer State field. Only ACTIVE accounts are processed either way, so behavior is unchanged.