### PR TITLE
feat: support multi-value tags via --tagSplit

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ connection "aws_engineering_team" {
 }
 ```
 
+#### Multi-value tags
+
+By default, a tag is matched by its exact value (`team=frontend` only matches `index .Tags "team,frontend"`).
+If an account can belong to more than one group at once, use `--tagSplit` to split a tag's value on one
+or more delimiter characters, per tag key. Each resulting value becomes its own aggregator group.
+
+E.g. with an account tagged `team=frontend:backend` and:
+```bash
+--tagSplit="team=:"
+```
+that account is included in both `index .Tags "team,frontend"` and `index .Tags "team,backend"` — the
+combined value `team,frontend:backend` is not registered, only the split values are.
+
+`--tagSplit` takes a `key=delimiter[,delimiter...]` pair (repeatable for multiple keys), where each
+comma-separated `delimiter` is a single character to split on, e.g. `--tagSplit="team=:,-"` splits the
+`team` tag on `:` **or** `-`. Only tags listed in `--tagSplit` are affected — every other tag keeps
+today's exact-match behavior unchanged. Valid delimiter characters are limited to AWS's supported tag
+character set: `. : + = @ _ / -`.
+
 
 ## Contribute
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ type Flags struct {
 	TemplatePath     string
 	LogFormat        string
 	SkipOUs          []string
+	TagSplit         map[string]string
 }
 
 var (
@@ -75,6 +76,7 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 	cmd.Flags().StringVar(&flags.TemplatePath, "template", "", "Custom connections template path")
 	cmd.Flags().StringVar(&flags.LogFormat, "log", "default", "Log format: default, json")
 	cmd.Flags().StringVar(&skipOUs, "skipOUs", "", "AWS OU IDs to skip from account connections")
+	cmd.Flags().StringToStringVar(&flags.TagSplit, "tagSplit", nil, `Per-tag delimiter character(s) to split a multi-value tag on, as key=delimiter[,delimiter...] (repeatable), e.g. --tagSplit="team=:,-" splits the "team" tag on ':' or '-'`)
 
 	if err := cmd.MarkFlagRequired("role"); err != nil {
 		panic(err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -97,6 +97,51 @@ func TestNewRootCmd_HappyPath_Defaults(t *testing.T) {
 	}
 }
 
+func TestNewRootCmd_TagSplit_Repeatable(t *testing.T) {
+	var got *cmd.Flags
+	run := func(_ context.Context, _ *slog.Logger, f *cmd.Flags) error {
+		got = f
+		return nil
+	}
+
+	_, err := execute(t, run,
+		"--role", "my-role",
+		"--tagSplit", "team=:",
+		"--tagSplit", "cost_center=+",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := ":"; got.TagSplit["team"] != want {
+		t.Errorf(`TagSplit["team"] = %q, want %q`, got.TagSplit["team"], want)
+	}
+	if want := "+"; got.TagSplit["cost_center"] != want {
+		t.Errorf(`TagSplit["cost_center"] = %q, want %q`, got.TagSplit["cost_center"], want)
+	}
+}
+
+// A comma inside a single --tagSplit occurrence's value (used to list multiple delimiter
+// characters, e.g. "team=:,-") must survive pflag's own parsing unmangled - it does, because
+// pflag.StringToStringVar only switches to comma-as-pair-separator (CSV) parsing when a single
+// occurrence's value contains more than one "=", which never happens for one key=value pair.
+func TestNewRootCmd_TagSplit_CommaInValue(t *testing.T) {
+	var got *cmd.Flags
+	run := func(_ context.Context, _ *slog.Logger, f *cmd.Flags) error {
+		got = f
+		return nil
+	}
+
+	_, err := execute(t, run, "--role", "my-role", "--tagSplit", "team=:,-")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := ":,-"; got.TagSplit["team"] != want {
+		t.Errorf(`TagSplit["team"] = %q, want %q`, got.TagSplit["team"], want)
+	}
+}
+
 func TestNewRootCmd_RoleRequired(t *testing.T) {
 	run := func(context.Context, *slog.Logger, *cmd.Flags) error {
 		t.Fatal("run should not be called when --role is missing")

--- a/generator/accounts.go
+++ b/generator/accounts.go
@@ -7,6 +7,73 @@ import (
 	"strings"
 )
 
+// validTagSplitDelimiters is the subset of AWS's supported tag character set that may be
+// used as a delimiter: letters, numbers, and ". : + = @ _ / -".
+const validTagSplitDelimiters = ".:+=@_/-"
+
+// parseDelimiters parses a --tagSplit value for one key (e.g. ":,-") into the set of
+// individual delimiter characters to split on. Delimiters are comma-separated, matching
+// pflag's own key=value1,key2=value2 convention for a single tag key's entry (a lone "," here
+// is safe: pflag.StringToStringVar only treats "," as a pair separator when a single --tagSplit
+// occurrence contains more than one "=").
+func parseDelimiters(key, raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+
+	var delimiters strings.Builder
+	for _, token := range strings.Split(raw, ",") {
+		runes := []rune(token)
+		if len(runes) != 1 {
+			return "", fmt.Errorf("tag %q: delimiter %q must be a single character", key, token)
+		}
+		if !strings.ContainsRune(validTagSplitDelimiters, runes[0]) {
+			return "", fmt.Errorf("tag %q: delimiter %q is not a valid AWS tag character; valid delimiters are %q", key, token, validTagSplitDelimiters)
+		}
+		delimiters.WriteRune(runes[0])
+	}
+	return delimiters.String(), nil
+}
+
+// validateTagSplit rejects any configured delimiter character outside validTagSplitDelimiters.
+func validateTagSplit(tagSplit map[string]string) error {
+	for key, raw := range tagSplit {
+		if _, err := parseDelimiters(key, raw); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// splitTagValue returns the individual values for a tag. If key has no configured delimiters
+// in tagSplit, value is returned unchanged (legacy single-value behavior). Otherwise value is
+// split on any of its configured delimiter characters, with whitespace trimmed and empty
+// sub-values dropped. tagSplit is assumed already validated (see validateTagSplit, called from
+// New before any AWS call), so a parse error here is treated defensively as a no-op.
+func splitTagValue(key, value string, tagSplit map[string]string) []string {
+	raw, ok := tagSplit[key]
+	if !ok {
+		return []string{value}
+	}
+
+	delimiters, err := parseDelimiters(key, raw)
+	if err != nil {
+		return []string{value}
+	}
+
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return strings.ContainsRune(delimiters, r)
+	})
+
+	values := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p := strings.TrimSpace(p); p != "" {
+			values = append(values, p)
+		}
+	}
+	return values
+}
+
 func (g *generator) Accounts(ctx context.Context) ([]Account, error) {
 	orgAccounts, err := g.client.ListAccounts(ctx)
 	if err != nil {
@@ -19,6 +86,11 @@ func (g *generator) Accounts(ctx context.Context) ([]Account, error) {
 			continue
 		}
 
+		tags := make(map[string][]string, len(acc.Tags))
+		for key, value := range acc.Tags {
+			tags[key] = splitTagValue(key, value, g.opts.TagSplit)
+		}
+
 		accounts = append(accounts, Account{
 			Name:             normalizeAccountName(acc.Name),
 			RoleARN:          fmt.Sprintf("arn:aws:iam::%s:role/%s", acc.ID, g.opts.RoleName),
@@ -26,7 +98,7 @@ func (g *generator) Accounts(ctx context.Context) ([]Account, error) {
 			ImportSchema:     g.opts.ImportSchema,
 			DefaultRegion:    g.opts.Region,
 			TargetRegions:    g.opts.TargetRegions,
-			Tags:             acc.Tags,
+			Tags:             tags,
 		})
 	}
 

--- a/generator/accounts_test.go
+++ b/generator/accounts_test.go
@@ -57,8 +57,8 @@ func TestGenerator_Accounts(t *testing.T) {
 	if got.RoleARN != "arn:aws:iam::111111111111:role/my-role" {
 		t.Errorf("RoleARN = %q", got.RoleARN)
 	}
-	if got.Tags["team"] != "foo" {
-		t.Errorf("Tags[team] = %q, want %q", got.Tags["team"], "foo")
+	if want := []string{"foo"}; len(got.Tags["team"]) != 1 || got.Tags["team"][0] != want[0] {
+		t.Errorf("Tags[team] = %v, want %v", got.Tags["team"], want)
 	}
 }
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -24,6 +24,10 @@ type generator struct {
 // New returns a Generator configured from the default AWS environment, assuming
 // opts.AssumeRoleArn first if set.
 func New(ctx context.Context, opts Options) (Generator, error) {
+	if err := validateTagSplit(opts.TagSplit); err != nil {
+		return nil, err
+	}
+
 	cfg, err := internalaws.LoadConfig(ctx, internalaws.Config{
 		AssumeRoleArn: opts.AssumeRoleArn,
 		Region:        opts.Region,

--- a/generator/render.go
+++ b/generator/render.go
@@ -55,13 +55,16 @@ func RenderCredentials(w io.Writer, accounts []Account) error {
 }
 
 // aggregateTags groups account names by "tagKey,tagValue", mirroring the historical template
-// lookup convention (index .Tags "key,value").
+// lookup convention (index .Tags "key,value"). A tag with multiple values (see Options.TagSplit)
+// contributes one entry per value.
 func aggregateTags(accounts []Account) map[string][]string {
 	tagged := make(map[string][]string)
 	for _, acc := range accounts {
-		for key, value := range acc.Tags {
-			tagKey := key + "," + value
-			tagged[tagKey] = append(tagged[tagKey], acc.Name)
+		for key, values := range acc.Tags {
+			for _, value := range values {
+				tagKey := key + "," + value
+				tagged[tagKey] = append(tagged[tagKey], acc.Name)
+			}
 		}
 	}
 	return tagged

--- a/generator/render_test.go
+++ b/generator/render_test.go
@@ -52,7 +52,7 @@ func TestRenderConnections_DefaultTemplate(t *testing.T) {
 			DefaultRegion: "us-east-1",
 			ImportSchema:  "enabled",
 			TargetRegions: []string{"*"},
-			Tags:          map[string]string{"compliance_rolling": "true"},
+			Tags:          map[string][]string{"sandbox_account": {"true"}},
 		},
 		{
 			Name:          "team_bar",
@@ -89,26 +89,26 @@ func TestParseConnectionsTemplate_InvalidPath(t *testing.T) {
 
 func TestAggregateTags(t *testing.T) {
 	accounts := []Account{
-		{Name: "team_foo", Tags: map[string]string{"compliance_rolling": "true"}},
-		{Name: "team_bar", Tags: map[string]string{"compliance_rolling": "true"}},
-		{Name: "team_baz", Tags: map[string]string{"compliance_rolling": "false"}},
+		{Name: "team_foo", Tags: map[string][]string{"sandbox_account": {"true"}}},
+		{Name: "team_bar", Tags: map[string][]string{"sandbox_account": {"true"}}},
+		{Name: "team_baz", Tags: map[string][]string{"sandbox_account": {"false"}}},
 	}
 
 	got := aggregateTags(accounts)
 
 	want := []string{"team_foo", "team_bar"}
-	names := got["compliance_rolling,true"]
+	names := got["sandbox_account,true"]
 	if len(names) != len(want) {
-		t.Fatalf("aggregateTags()[compliance_rolling,true] = %v, want %v", names, want)
+		t.Fatalf("aggregateTags()[sandbox_account,true] = %v, want %v", names, want)
 	}
 	seen := map[string]bool{names[0]: true, names[1]: true}
 	for _, w := range want {
 		if !seen[w] {
-			t.Errorf("aggregateTags()[compliance_rolling,true] missing %q, got %v", w, names)
+			t.Errorf("aggregateTags()[sandbox_account,true] missing %q, got %v", w, names)
 		}
 	}
 
-	if names := got["compliance_rolling,false"]; len(names) != 1 || names[0] != "team_baz" {
-		t.Errorf("aggregateTags()[compliance_rolling,false] = %v, want [team_baz]", names)
+	if names := got["sandbox_account,false"]; len(names) != 1 || names[0] != "team_baz" {
+		t.Errorf("aggregateTags()[sandbox_account,false] = %v, want [team_baz]", names)
 	}
 }

--- a/generator/tagsplit_test.go
+++ b/generator/tagsplit_test.go
@@ -1,0 +1,180 @@
+package generator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	internalaws "github.com/unicrons/steampipe-config-generator/internal/aws"
+)
+
+// Case 1: a tag key with no configured delimiter keeps today's exact-match behavior.
+func TestSplitTagValue_NoDelimiterConfigured(t *testing.T) {
+	got := splitTagValue("team", "frontend:backend", nil)
+	want := []string{"frontend:backend"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("splitTagValue() = %v, want %v", got, want)
+	}
+}
+
+// Case 2: a tag key with one configured delimiter splits into N map entries.
+func TestSplitTagValue_OneDelimiter(t *testing.T) {
+	got := splitTagValue("team", "frontend:backend", map[string]string{"team": ":"})
+	want := []string{"frontend", "backend"}
+	if !equalUnordered(got, want) {
+		t.Errorf("splitTagValue() = %v, want %v", got, want)
+	}
+}
+
+// Case 3: multiple configured delimiter characters (comma-separated in the flag value) split
+// on any of them.
+func TestSplitTagValue_MultipleDelimiters(t *testing.T) {
+	got := splitTagValue("team", "frontend:backend-platform", map[string]string{"team": ":,-"})
+	want := []string{"frontend", "backend", "platform"}
+	if !equalUnordered(got, want) {
+		t.Errorf("splitTagValue() = %v, want %v", got, want)
+	}
+}
+
+// A comma-separated delimiter list parses correctly even though pflag.StringToStringVar also
+// uses "," as its own pair separator - confirmed safe because a single --tagSplit occurrence
+// with exactly one "=" never enters pflag's CSV parser (see TestNewRootCmd_TagSplit_CommaInValue).
+func TestParseDelimiters_CommaSeparated(t *testing.T) {
+	got, err := parseDelimiters("team", ":,-")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !equalUnordered(strings.Split(got, ""), []string{":", "-"}) {
+		t.Errorf("parseDelimiters() = %q, want the characters ':' and '-'", got)
+	}
+}
+
+func TestParseDelimiters_MultiCharacterTokenRejected(t *testing.T) {
+	_, err := parseDelimiters("team", "::")
+	if err == nil {
+		t.Fatal("expected an error for a multi-character delimiter token")
+	}
+}
+
+// Case 4: an invalid delimiter character is rejected with a clear error, before any AWS call.
+func TestValidateTagSplit_InvalidDelimiter(t *testing.T) {
+	err := validateTagSplit(map[string]string{"team": "!"})
+	if err == nil {
+		t.Fatal("expected an error for an invalid delimiter character")
+	}
+	if !strings.Contains(err.Error(), "team") {
+		t.Errorf("error should mention the offending tag key, got: %v", err)
+	}
+}
+
+func TestNew_InvalidTagSplitDelimiter(t *testing.T) {
+	_, err := New(context.Background(), Options{
+		RoleName: "my-role",
+		TagSplit: map[string]string{"team": "!"},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an invalid delimiter character")
+	}
+}
+
+// Case 5: empty and whitespace-only sub-values (trailing/double delimiters) are dropped.
+func TestSplitTagValue_DropsEmptyAndWhitespaceSubValues(t *testing.T) {
+	got := splitTagValue("team", "frontend::  :backend:", map[string]string{"team": ":"})
+	want := []string{"frontend", "backend"}
+	if !equalUnordered(got, want) {
+		t.Errorf("splitTagValue() = %v, want %v", got, want)
+	}
+}
+
+// A key with a configured delimiter whose value doesn't actually contain that delimiter still
+// goes through the split path, but yields a single unchanged value - same visible result as
+// the no-delimiter-configured case, via a different code path.
+func TestSplitTagValue_ConfiguredDelimiterNotPresentInValue(t *testing.T) {
+	got := splitTagValue("team", "frontend", map[string]string{"team": ":"})
+	want := []string{"frontend"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("splitTagValue() = %v, want %v", got, want)
+	}
+}
+
+// An empty delimiter set for a key is valid (zero characters to reject) and acts as a no-op:
+// nothing matches, so the value is returned whole, same as if the key weren't configured.
+func TestSplitTagValue_EmptyDelimiterSetIsNoOp(t *testing.T) {
+	if err := validateTagSplit(map[string]string{"team": ""}); err != nil {
+		t.Fatalf("unexpected error for an empty delimiter set: %v", err)
+	}
+
+	got := splitTagValue("team", "frontend:backend", map[string]string{"team": ""})
+	want := []string{"frontend:backend"}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Errorf("splitTagValue() = %v, want %v", got, want)
+	}
+}
+
+// Two different tag keys can have two different, independent delimiter sets configured at
+// the same time, without bleeding into each other.
+func TestSplitTagValue_MultipleKeysWithDifferentDelimiters(t *testing.T) {
+	tagSplit := map[string]string{"team": ":", "cost_center": "+"}
+
+	gotTeam := splitTagValue("team", "frontend:backend", tagSplit)
+	if want := []string{"frontend", "backend"}; !equalUnordered(gotTeam, want) {
+		t.Errorf(`splitTagValue("team", ...) = %v, want %v`, gotTeam, want)
+	}
+
+	gotCostCenter := splitTagValue("cost_center", "100+200", tagSplit)
+	if want := []string{"100", "200"}; !equalUnordered(gotCostCenter, want) {
+		t.Errorf(`splitTagValue("cost_center", ...) = %v, want %v`, gotCostCenter, want)
+	}
+}
+
+// End-to-end: a multi-value tag resolves into two separate aggregator groups, replacing the
+// single combined-value entry, while an unrelated tag keeps its legacy single-entry behavior.
+func TestGenerator_Accounts_MultiValueTagAggregation(t *testing.T) {
+	client := &fakeOrganizationsClient{
+		accounts: []internalaws.Account{
+			{ID: "111111111111", Name: "account-a", Tags: map[string]string{"team": "frontend:backend", "env": "prod"}},
+			{ID: "222222222222", Name: "account-b", Tags: map[string]string{"team": "backend"}},
+		},
+	}
+	g := &generator{
+		client: client,
+		opts:   Options{RoleName: "my-role", TagSplit: map[string]string{"team": ":"}},
+	}
+
+	accounts, err := g.Accounts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tagged := aggregateTags(accounts)
+
+	if _, ok := tagged["team,frontend:backend"]; ok {
+		t.Error("the combined value entry should not exist - it must be replaced by the split entries")
+	}
+	if names := tagged["team,frontend"]; !equalUnordered(names, []string{"account_a"}) {
+		t.Errorf(`tagged["team,frontend"] = %v, want [account_a]`, names)
+	}
+	if names := tagged["team,backend"]; !equalUnordered(names, []string{"account_a", "account_b"}) {
+		t.Errorf(`tagged["team,backend"] = %v, want [account_a account_b]`, names)
+	}
+	if names := tagged["env,prod"]; !equalUnordered(names, []string{"account_a"}) {
+		t.Errorf(`tagged["env,prod"] = %v, want [account_a] (unrelated tag, no split configured)`, names)
+	}
+}
+
+func equalUnordered(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := make(map[string]int)
+	for _, v := range got {
+		seen[v]++
+	}
+	for _, v := range want {
+		if seen[v] == 0 {
+			return false
+		}
+		seen[v]--
+	}
+	return true
+}

--- a/generator/types.go
+++ b/generator/types.go
@@ -1,7 +1,9 @@
 package generator
 
 // Account is an AWS Organizations account together with the data needed to render its
-// Steampipe connection and credentials entries.
+// Steampipe connection and credentials entries. Tags maps each tag key to its value(s) - a
+// single-element slice for tags with no configured split, or multiple elements for tags
+// listed in Options.TagSplit.
 type Account struct {
 	Name             string
 	RoleARN          string
@@ -9,7 +11,7 @@ type Account struct {
 	ImportSchema     string
 	DefaultRegion    string
 	TargetRegions    []string
-	Tags             map[string]string
+	Tags             map[string][]string
 }
 
 // Options configures a Generator.
@@ -29,4 +31,9 @@ type Options struct {
 	TargetRegions []string
 	// SkipOUs lists organizational unit IDs whose accounts are excluded from the result.
 	SkipOUs []string
+	// TagSplit maps a tag key to the set of delimiter characters (e.g. ":-") its value
+	// should be split on. Tags whose key isn't listed here keep their raw value, unchanged.
+	// Only characters from AWS's supported tag character set are valid delimiters:
+	// . : + = @ _ / -
+	TagSplit map[string]string
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func run(ctx context.Context, log *slog.Logger, flags *cmd.Flags) error {
 		ImportSchema:     flags.ImportSchema,
 		TargetRegions:    flags.TargetRegions,
 		SkipOUs:          flags.SkipOUs,
+		TagSplit:         flags.TagSplit,
 	})
 	if err != nil {
 		return fmt.Errorf("creating generator: %w", err)


### PR DESCRIPTION
Add a --tagSplit key=delimiter[,delimiter...] flag (repeatable per tag key) that splits a tag's value into individual values on one or more delimiter characters, registering the account under each resulting value instead of the combined one. Tags not listed in --tagSplit keep their exact-match behavior unchanged.

Only characters from AWS's supported tag character set are valid delimiters (. : + = @ _ / -); anything else is rejected before any AWS call.

Account.Tags changes from map[string]string to map[string][]string so the split happens once, during the fetch (generator.Accounts), and RenderConnections/aggregateTags stay unaware of TagSplit.