### PR TITLE
ci: add CI, release pipeline, and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[dep][actions]"
+      include: "scope"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[dep][go]"
+      include: "scope"
+    groups:
+      golang-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: ci
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -race ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,16 +10,22 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
+    ldflags:
+      '-s -w -X github.com/unicrons/{{ .ProjectName }}/cmd.Version={{.Version}} -X github.com/unicrons/{{ .ProjectName }}/cmd.Commit={{.Commit}} -X github.com/unicrons/{{ .ProjectName }}/cmd.Date={{.Date}}'
+
+universal_binaries:
+  - replace: true
 
 archives:
-  - format: zip
+  - formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
     - goos: linux
-      format: tar.gz
+      formats: [tar.gz]
 
 changelog:
   sort: asc

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,8 +19,8 @@ func NewVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "steampipe-config-generator %s (commit %s, built %s)\n", Version, Commit, Date)
-			return nil
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "steampipe-config-generator %s (commit %s, built %s)\n", Version, Commit, Date)
+			return err
 		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -52,10 +52,14 @@ func writeCredentialsFile(path string, accounts []generator.Account) error {
 	if err != nil {
 		return fmt.Errorf("creating aws credentials file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	if err := generator.RenderCredentials(file, accounts); err != nil {
 		return fmt.Errorf("rendering aws credentials file: %w", err)
+	}
+
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing aws credentials file: %w", err)
 	}
 	return nil
 }
@@ -74,10 +78,14 @@ func writeConnectionsFile(path, templatePath string, accounts []generator.Accoun
 	if err != nil {
 		return fmt.Errorf("creating aws connections file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	if err := generator.RenderConnections(file, accounts, tmpl); err != nil {
 		return fmt.Errorf("rendering aws connections file: %w", err)
+	}
+
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing aws connections file: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
- .github/workflows/ci.yml: test, lint (golangci-lint), and vulncheck (govulncheck) on every push/PR to main. All three are blocking - verified locally there's no existing debt to justify continue-on-error.
- .github/workflows/release.yml: runs GoReleaser on tag push.
- .github/dependabot.yml: weekly, grouped gomod/github-actions updates.
- .goreleaser.yaml: inject version/commit/date via ldflags into cmd.Version/Commit/Date, add windows to the build matrix, and combine the darwin binaries into one universal (fat) binary. Also fixed two deprecated archive config keys found along the way.

Fixes 3 golangci-lint findings (errcheck) in main.go and cmd/version.go: unchecked file.Close()/fmt.Fprintf return values.