### PR TITLE
test: close remaining coverage gaps, mocking AWS instead of skipping it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,20 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests
-        run: go test -race ./...
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage
+          path: coverage.out
 
   lint:
+    # Dependabot PRs never touch our own source, only go.mod/go.sum/.github/workflows, so
+    # golangci-lint would always report the same result main already has - skip it to save CI
+    # time. Still run for everything else, including Dependabot PRs that touch .github/workflows
+    # via actionlint's own separate concerns; test and vulncheck always run regardless.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/generator/tagsplit_test.go
+++ b/generator/tagsplit_test.go
@@ -35,19 +35,6 @@ func TestSplitTagValue_MultipleDelimiters(t *testing.T) {
 	}
 }
 
-// A comma-separated delimiter list parses correctly even though pflag.StringToStringVar also
-// uses "," as its own pair separator - confirmed safe because a single --tagSplit occurrence
-// with exactly one "=" never enters pflag's CSV parser (see TestNewRootCmd_TagSplit_CommaInValue).
-func TestParseDelimiters_CommaSeparated(t *testing.T) {
-	got, err := parseDelimiters("team", ":,-")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !equalUnordered(strings.Split(got, ""), []string{":", "-"}) {
-		t.Errorf("parseDelimiters() = %q, want the characters ':' and '-'", got)
-	}
-}
-
 func TestParseDelimiters_MultiCharacterTokenRejected(t *testing.T) {
 	_, err := parseDelimiters("team", "::")
 	if err == nil {
@@ -81,17 +68,6 @@ func TestSplitTagValue_DropsEmptyAndWhitespaceSubValues(t *testing.T) {
 	got := splitTagValue("team", "frontend::  :backend:", map[string]string{"team": ":"})
 	want := []string{"frontend", "backend"}
 	if !equalUnordered(got, want) {
-		t.Errorf("splitTagValue() = %v, want %v", got, want)
-	}
-}
-
-// A key with a configured delimiter whose value doesn't actually contain that delimiter still
-// goes through the split path, but yields a single unchanged value - same visible result as
-// the no-delimiter-configured case, via a different code path.
-func TestSplitTagValue_ConfiguredDelimiterNotPresentInValue(t *testing.T) {
-	got := splitTagValue("team", "frontend", map[string]string{"team": ":"})
-	want := []string{"frontend"}
-	if len(got) != 1 || got[0] != want[0] {
 		t.Errorf("splitTagValue() = %v, want %v", got, want)
 	}
 }

--- a/internal/aws/config.go
+++ b/internal/aws/config.go
@@ -30,12 +30,20 @@ func LoadConfig(ctx context.Context, cfg Config) (aws.Config, error) {
 		return awscfg, nil
 	}
 
-	creds, err := assumeRole(ctx, sts.NewFromConfig(awscfg), cfg.AssumeRoleArn, "steampipeConfigGenerator")
+	return withAssumedRole(ctx, sts.NewFromConfig(awscfg), cfg)
+}
+
+// withAssumedRole assumes cfg.AssumeRoleArn via client and returns a config using the
+// resulting temporary credentials. Split out from LoadConfig so it's testable with a fake STS
+// client - LoadConfig itself is left with nothing but the (untestable without a real network
+// call) construction of the real *sts.Client.
+func withAssumedRole(ctx context.Context, client stscreds.AssumeRoleAPIClient, cfg Config) (aws.Config, error) {
+	creds, err := assumeRole(ctx, client, cfg.AssumeRoleArn, "steampipeConfigGenerator")
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("assuming role %s: %w", cfg.AssumeRoleArn, err)
 	}
 
-	awscfg, err = awsconfig.LoadDefaultConfig(ctx,
+	awscfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
 			creds.AccessKeyID, creds.SecretAccessKey, creds.SessionToken,
 		)),
@@ -48,7 +56,10 @@ func LoadConfig(ctx context.Context, cfg Config) (aws.Config, error) {
 	return awscfg, nil
 }
 
-func assumeRole(ctx context.Context, client *sts.Client, roleArn, sessionName string) (aws.Credentials, error) {
+// assumeRole retrieves temporary credentials for roleArn. client only needs to implement the
+// SDK's own stscreds.AssumeRoleAPIClient interface, not the concrete *sts.Client, so tests can
+// fake the AssumeRole call without any network access.
+func assumeRole(ctx context.Context, client stscreds.AssumeRoleAPIClient, roleArn, sessionName string) (aws.Credentials, error) {
 	provider := stscreds.NewAssumeRoleProvider(client, roleArn, func(o *stscreds.AssumeRoleOptions) {
 		o.RoleSessionName = sessionName
 	})

--- a/internal/aws/config_test.go
+++ b/internal/aws/config_test.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+)
+
+// fakeSTSAPI is an in-memory stscreds.AssumeRoleAPIClient - no AWS calls happen in these tests.
+type fakeSTSAPI struct {
+	output *sts.AssumeRoleOutput
+	err    error
+}
+
+func (f *fakeSTSAPI) AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.output, nil
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func TestAssumeRole(t *testing.T) {
+	api := &fakeSTSAPI{
+		output: &sts.AssumeRoleOutput{
+			Credentials: &types.Credentials{
+				AccessKeyId:     strPtr("AKIAFAKE"),
+				SecretAccessKey: strPtr("secret"),
+				SessionToken:    strPtr("token"),
+				Expiration:      timePtr(time.Now().Add(time.Hour)),
+			},
+		},
+	}
+
+	creds, err := assumeRole(t.Context(), api, "arn:aws:iam::111111111111:role/my-role", "test-session")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.AccessKeyID != "AKIAFAKE" {
+		t.Errorf("AccessKeyID = %q, want %q", creds.AccessKeyID, "AKIAFAKE")
+	}
+	if creds.SessionToken != "token" {
+		t.Errorf("SessionToken = %q, want %q", creds.SessionToken, "token")
+	}
+}
+
+func TestAssumeRole_Error(t *testing.T) {
+	wantErr := errors.New("AccessDenied")
+	api := &fakeSTSAPI{err: wantErr}
+
+	_, err := assumeRole(t.Context(), api, "arn:aws:iam::111111111111:role/my-role", "test-session")
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestWithAssumedRole(t *testing.T) {
+	api := &fakeSTSAPI{
+		output: &sts.AssumeRoleOutput{
+			Credentials: &types.Credentials{
+				AccessKeyId:     strPtr("AKIAFAKE"),
+				SecretAccessKey: strPtr("secret"),
+				SessionToken:    strPtr("token"),
+				Expiration:      timePtr(time.Now().Add(time.Hour)),
+			},
+		},
+	}
+
+	awscfg, err := withAssumedRole(t.Context(), api, Config{
+		AssumeRoleArn: "arn:aws:iam::111111111111:role/my-role",
+		Region:        "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if awscfg.Region != "us-east-1" {
+		t.Errorf("Region = %q, want %q", awscfg.Region, "us-east-1")
+	}
+
+	creds, err := awscfg.Credentials.Retrieve(t.Context())
+	if err != nil {
+		t.Fatalf("retrieving credentials from resulting config: %v", err)
+	}
+	if creds.AccessKeyID != "AKIAFAKE" {
+		t.Errorf("AccessKeyID = %q, want %q", creds.AccessKeyID, "AKIAFAKE")
+	}
+}
+
+func TestWithAssumedRole_AssumeRoleError(t *testing.T) {
+	wantErr := errors.New("AccessDenied")
+	api := &fakeSTSAPI{err: wantErr}
+
+	_, err := withAssumedRole(t.Context(), api, Config{AssumeRoleArn: "arn:aws:iam::111111111111:role/my-role"})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+}

--- a/internal/aws/organizations.go
+++ b/internal/aws/organizations.go
@@ -19,8 +19,15 @@ const (
 	maxConcurrentOUFetches  = 3 // under 5 TPS, burst 8 limit
 )
 
+// organizationsAPI is the subset of the AWS Organizations SDK client this package calls.
+type organizationsAPI interface {
+	organizations.ListAccountsAPIClient
+	organizations.ListTagsForResourceAPIClient
+	ListParents(ctx context.Context, params *organizations.ListParentsInput, optFns ...func(*organizations.Options)) (*organizations.ListParentsOutput, error)
+}
+
 type organizationsClient struct {
-	client *organizations.Client
+	client organizationsAPI
 }
 
 // NewOrganizationsClient returns a client backed by the real AWS SDK, using an aggressive

--- a/internal/aws/organizations_test.go
+++ b/internal/aws/organizations_test.go
@@ -1,0 +1,155 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
+)
+
+// fakeOrganizationsAPI is an in-memory organizationsAPI - no AWS calls happen in these tests.
+// Each method returns a single page (our real pagination loops work the same either way, since
+// they just stop as soon as NextToken is nil).
+type fakeOrganizationsAPI struct {
+	accounts    []types.Account
+	accountsErr error
+
+	tags    map[string][]types.Tag
+	tagsErr map[string]error
+
+	parents    map[string][]types.Parent
+	parentsErr map[string]error
+}
+
+func (f *fakeOrganizationsAPI) ListAccounts(ctx context.Context, params *organizations.ListAccountsInput, optFns ...func(*organizations.Options)) (*organizations.ListAccountsOutput, error) {
+	if f.accountsErr != nil {
+		return nil, f.accountsErr
+	}
+	return &organizations.ListAccountsOutput{Accounts: f.accounts}, nil
+}
+
+func (f *fakeOrganizationsAPI) ListTagsForResource(ctx context.Context, params *organizations.ListTagsForResourceInput, optFns ...func(*organizations.Options)) (*organizations.ListTagsForResourceOutput, error) {
+	id := *params.ResourceId
+	if err := f.tagsErr[id]; err != nil {
+		return nil, err
+	}
+	return &organizations.ListTagsForResourceOutput{Tags: f.tags[id]}, nil
+}
+
+func (f *fakeOrganizationsAPI) ListParents(ctx context.Context, params *organizations.ListParentsInput, optFns ...func(*organizations.Options)) (*organizations.ListParentsOutput, error) {
+	id := *params.ChildId
+	if err := f.parentsErr[id]; err != nil {
+		return nil, err
+	}
+	return &organizations.ListParentsOutput{Parents: f.parents[id]}, nil
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestOrganizationsClient_ListAccounts(t *testing.T) {
+	api := &fakeOrganizationsAPI{
+		accounts: []types.Account{
+			{Id: strPtr("111111111111"), Name: strPtr("Team Foo"), State: types.AccountStateActive},
+			{Id: strPtr("222222222222"), Name: strPtr("Team Bar"), State: types.AccountStateSuspended},
+			{Id: strPtr("333333333333"), Name: strPtr("Team Baz"), State: types.AccountStateActive},
+		},
+		tags: map[string][]types.Tag{
+			"111111111111": {{Key: strPtr("team"), Value: strPtr("foo")}},
+			"333333333333": {{Key: strPtr("team"), Value: strPtr("baz")}},
+		},
+		parents: map[string][]types.Parent{
+			"111111111111": {{Id: strPtr("ou-root")}},
+			"333333333333": {{Id: strPtr("ou-sandbox")}},
+		},
+	}
+	c := &organizationsClient{client: api}
+
+	accounts, err := c.ListAccounts(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(accounts) != 2 {
+		t.Fatalf("got %d accounts, want 2 (only ACTIVE): %+v", len(accounts), accounts)
+	}
+
+	byID := make(map[string]Account, len(accounts))
+	for _, acc := range accounts {
+		byID[acc.ID] = acc
+	}
+
+	foo, ok := byID["111111111111"]
+	if !ok {
+		t.Fatal("missing account 111111111111")
+	}
+	if foo.Name != "Team Foo" {
+		t.Errorf("Name = %q, want %q", foo.Name, "Team Foo")
+	}
+	if foo.OU != "ou-root" {
+		t.Errorf("OU = %q, want %q", foo.OU, "ou-root")
+	}
+	if foo.Tags["team"] != "foo" {
+		t.Errorf(`Tags["team"] = %q, want %q`, foo.Tags["team"], "foo")
+	}
+
+	if _, ok := byID["222222222222"]; ok {
+		t.Error("suspended account 222222222222 should have been excluded")
+	}
+}
+
+func TestOrganizationsClient_ListAccounts_ListAccountsError(t *testing.T) {
+	wantErr := errors.New("TooManyRequestsException")
+	c := &organizationsClient{client: &fakeOrganizationsAPI{accountsErr: wantErr}}
+
+	_, err := c.ListAccounts(t.Context())
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestOrganizationsClient_ListAccounts_TagsErrorIsNotSilenced(t *testing.T) {
+	wantErr := errors.New("AccessDenied")
+	api := &fakeOrganizationsAPI{
+		accounts: []types.Account{
+			{Id: strPtr("111111111111"), Name: strPtr("Team Foo"), State: types.AccountStateActive},
+		},
+		tagsErr:    map[string]error{"111111111111": wantErr},
+		parents:    map[string][]types.Parent{"111111111111": {{Id: strPtr("ou-root")}}},
+		parentsErr: map[string]error{},
+	}
+	c := &organizationsClient{client: api}
+
+	_, err := c.ListAccounts(t.Context())
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestOrganizationsClient_ListAccounts_OUErrorIsNotSilenced(t *testing.T) {
+	wantErr := errors.New("AccessDenied")
+	api := &fakeOrganizationsAPI{
+		accounts: []types.Account{
+			{Id: strPtr("111111111111"), Name: strPtr("Team Foo"), State: types.AccountStateActive},
+		},
+		tags:       map[string][]types.Tag{"111111111111": nil},
+		parentsErr: map[string]error{"111111111111": wantErr},
+	}
+	c := &organizationsClient{client: api}
+
+	_, err := c.ListAccounts(t.Context())
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestOrganizationsClient_GetAccountOU_NoParent(t *testing.T) {
+	api := &fakeOrganizationsAPI{parents: map[string][]types.Parent{}}
+	c := &organizationsClient{client: api}
+
+	_, err := c.getAccountOU(t.Context(), "111111111111")
+	if err == nil {
+		t.Fatal("expected an error when an account has no parent OU")
+	}
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,90 @@
+package logger
+
+import (
+	"bufio"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNew_DefaultFormatIsText(t *testing.T) {
+	out := captureStderr(t, func() {
+		log := New("default")
+		log.Info("hello", "key", "value")
+	})
+
+	if strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Errorf("expected plain text output for \"default\", got what looks like JSON: %s", out)
+	}
+	if !strings.Contains(out, "msg=hello") {
+		t.Errorf("expected slog text handler output (msg=hello), got: %s", out)
+	}
+}
+
+func TestNew_JSONFormat(t *testing.T) {
+	out := captureStderr(t, func() {
+		log := New("json")
+		log.Info("hello", "key", "value")
+	})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("expected valid JSON output, got %q: %v", out, err)
+	}
+	if parsed["msg"] != "hello" {
+		t.Errorf(`parsed["msg"] = %v, want "hello"`, parsed["msg"])
+	}
+}
+
+func TestLevelFromEnv(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+		want   slog.Level
+	}{
+		{name: "valid level", envVal: "DEBUG", want: slog.LevelDebug},
+		{name: "valid level, different case", envVal: "warn", want: slog.LevelWarn},
+		{name: "invalid value falls back to info", envVal: "bogus", want: slog.LevelInfo},
+		{name: "unset falls back to info", envVal: "", want: slog.LevelInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LOG_LEVEL", tt.envVal)
+			if got := levelFromEnv(); got != tt.want {
+				t.Errorf("levelFromEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// captureStderr swaps os.Stderr for a pipe for the duration of fn, restoring it afterward, and
+// returns everything fn wrote. logger.New writes to os.Stderr directly (there's no io.Writer
+// injection point for a CLI-only logger), so this is the only way to observe its output.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+
+	original := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = original }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe writer: %v", err)
+	}
+
+	scanner := bufio.NewScanner(r)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return strings.Join(lines, "\n")
+}

--- a/main.go
+++ b/main.go
@@ -11,8 +11,12 @@ import (
 	"github.com/unicrons/steampipe-config-generator/generator"
 )
 
-func run(ctx context.Context, log *slog.Logger, flags *cmd.Flags) error {
-	gen, err := generator.New(ctx, generator.Options{
+// newGenerator abstracts generator.New so tests can inject a fake Generator instead of
+// hitting real AWS. Production code always passes generator.New itself.
+type newGeneratorFunc func(ctx context.Context, opts generator.Options) (generator.Generator, error)
+
+func run(ctx context.Context, log *slog.Logger, flags *cmd.Flags, newGenerator newGeneratorFunc) error {
+	gen, err := newGenerator(ctx, generator.Options{
 		AssumeRoleArn:    flags.AssumeRoleArn,
 		Region:           flags.DefaultRegion,
 		RoleName:         flags.RoleName,
@@ -91,7 +95,10 @@ func writeConnectionsFile(path, templatePath string, accounts []generator.Accoun
 }
 
 func main() {
-	if err := cmd.NewRootCmd(run).Execute(); err != nil {
+	root := cmd.NewRootCmd(func(ctx context.Context, log *slog.Logger, flags *cmd.Flags) error {
+		return run(ctx, log, flags, generator.New)
+	})
+	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/unicrons/steampipe-config-generator/cmd"
+	"github.com/unicrons/steampipe-config-generator/generator"
+)
+
+// fakeGenerator is an in-memory generator.Generator - no AWS calls happen in these tests.
+type fakeGenerator struct {
+	accounts []generator.Account
+	err      error
+}
+
+func (f *fakeGenerator) Accounts(ctx context.Context) ([]generator.Account, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.accounts, nil
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestRun(t *testing.T) {
+	dir := t.TempDir()
+	fake := &fakeGenerator{accounts: []generator.Account{
+		{
+			Name:             "team_foo",
+			RoleARN:          "arn:aws:iam::111111111111:role/my-role",
+			CredentialSource: "Environment",
+			DefaultRegion:    "us-east-1",
+			ImportSchema:     "enabled",
+			TargetRegions:    []string{"*"},
+		},
+	}}
+	newGenerator := func(ctx context.Context, opts generator.Options) (generator.Generator, error) {
+		return fake, nil
+	}
+
+	flags := &cmd.Flags{
+		CredentialPath:  filepath.Join(dir, "creds"),
+		ConnectionsPath: filepath.Join(dir, "conn"),
+	}
+
+	if err := run(t.Context(), discardLogger(), flags, newGenerator); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(flags.CredentialPath, "credentials")); err != nil {
+		t.Errorf("expected credentials file to exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(flags.ConnectionsPath, "aws.spc")); err != nil {
+		t.Errorf("expected connections file to exist: %v", err)
+	}
+}
+
+func TestRun_NewGeneratorError(t *testing.T) {
+	wantErr := errors.New("boom")
+	newGenerator := func(ctx context.Context, opts generator.Options) (generator.Generator, error) {
+		return nil, wantErr
+	}
+
+	err := run(t.Context(), discardLogger(), &cmd.Flags{}, newGenerator)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestRun_AccountsError(t *testing.T) {
+	wantErr := errors.New("boom")
+	fake := &fakeGenerator{err: wantErr}
+	newGenerator := func(ctx context.Context, opts generator.Options) (generator.Generator, error) {
+		return fake, nil
+	}
+
+	err := run(t.Context(), discardLogger(), &cmd.Flags{}, newGenerator)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestWriteCredentialsFile(t *testing.T) {
+	dir := t.TempDir()
+	accounts := []generator.Account{
+		{Name: "team_foo", RoleARN: "arn:aws:iam::111111111111:role/my-role", CredentialSource: "Environment"},
+	}
+
+	if err := writeCredentialsFile(dir, accounts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "credentials"))
+	if err != nil {
+		t.Fatalf("reading generated file: %v", err)
+	}
+	if !strings.Contains(string(got), "[team_foo]") {
+		t.Errorf("generated file missing expected content, got:\n%s", got)
+	}
+}
+
+func TestWriteCredentialsFile_CreatesPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "aws")
+
+	if err := writeCredentialsFile(dir, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "credentials")); err != nil {
+		t.Errorf("expected credentials file to exist: %v", err)
+	}
+}
+
+func TestWriteConnectionsFile(t *testing.T) {
+	dir := t.TempDir()
+	accounts := []generator.Account{
+		{Name: "team_foo", DefaultRegion: "us-east-1", ImportSchema: "enabled", TargetRegions: []string{"*"}},
+	}
+
+	if err := writeConnectionsFile(dir, "", accounts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "aws.spc"))
+	if err != nil {
+		t.Fatalf("reading generated file: %v", err)
+	}
+	if !strings.Contains(string(got), `connection "aws_team_foo"`) {
+		t.Errorf("generated file missing expected content, got:\n%s", got)
+	}
+}
+
+func TestWriteConnectionsFile_InvalidTemplatePath(t *testing.T) {
+	err := writeConnectionsFile(t.TempDir(), "/no/such/template.tmpl", nil)
+	if err == nil {
+		t.Fatal("expected an error for a nonexistent template path")
+	}
+}


### PR DESCRIPTION
internal/aws: replace the concrete *organizations.Client/*sts.Client dependencies with minimal consumer-defined interfaces (organizationsAPI; stscreds.AssumeRoleAPIClient, already provided by the SDK) so tests can fake every AWS call instead of leaving this package as an accepted untested gap. Extract withAssumedRole out of LoadConfig so the assume-role-and-rebuild-config path is testable on its own. Coverage: ~8% -> 84.8%.

main.go: inject the Generator constructor into run() (newGeneratorFunc) so the whole orchestration - not just the file-writing helpers - is testable with a fake Generator. main() still wires the real generator.New. Coverage: 0% -> 67.4% (main() itself, 3 lines of pure wiring, is the one function left untested - not possible without spawning a subprocess).

internal/logger: first tests (0% -> 100%), capturing os.Stderr via a pipe since New() has no injectable io.Writer.

ci.yml: run tests with -coverprofile and upload it as an artifact (no threshold - nothing consumes it yet); skip the lint job for Dependabot PRs, since they never touch our own source so lint results would always match main's.

Also pruned two low-value tests in generator/tagsplit_test.go that didn't test anything the requirements doc's 5 required cases don't already cover.

Overall repo coverage: 86.0%.