### PR TITLE
Log output file paths and allow "=" as a --tagSplit delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Versioning](#versioning). Everything below shipped since `v0.1.2` and will ship 
   single-value tags are unaffected. See the README for examples.
 - `--version` flag and `version` subcommand, with version/commit/date injected at build time.
 - `--help` (via Cobra), documenting every flag.
+- Logs now include the path of each config file written (AWS credentials file and Steampipe
+  connections file).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Manage your [Steampipe](https://steampipe.io/) AWS config files at scale!
 
 *steampipe-config-generator* is a tool that generates configuration files for [steampipe-aws-plugin](https://hub.steampipe.io/plugins/turbot/aws). These files are used by Steampipe AWS plugin to connect to your AWS Accounts and fetch the desired data.
 
-We have created this tool to facilitate the creation and management of these files in organizations with multiple accounts.  
+We have created this tool to facilitate the creation and management of these files in organizations with multiple accounts.
 If you want more details about this, check our blog post: [Automate your Steampipe AWS configuration with AWS Organizations](https://unicrons.cloud/en/2024/10/18/automate-your-steampipe-aws-configuration-with-aws-organizations/)
 
 ![](./docs/flow.png)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 		flags         Flags
 		targetRegions string
 		skipOUs       string
+		rawTagSplit   []string
 	)
 
 	cmd := &cobra.Command{
@@ -54,6 +55,12 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 			if err := validateFlagValues(&flags); err != nil {
 				return err
 			}
+
+			tagSplit, err := parseTagSplit(rawTagSplit)
+			if err != nil {
+				return err
+			}
+			flags.TagSplit = tagSplit
 
 			log := logger.New(flags.LogFormat)
 
@@ -76,7 +83,7 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 	cmd.Flags().StringVar(&flags.TemplatePath, "template", "", "Custom connections template path")
 	cmd.Flags().StringVar(&flags.LogFormat, "log", "default", "Log format: default, json")
 	cmd.Flags().StringVar(&skipOUs, "skipOUs", "", "AWS OU IDs to skip from account connections")
-	cmd.Flags().StringToStringVar(&flags.TagSplit, "tagSplit", nil, `Per-tag delimiter character(s) to split a multi-value tag on, as key=delimiter[,delimiter...] (repeatable), e.g. --tagSplit="team=:,-" splits the "team" tag on ':' or '-'`)
+	cmd.Flags().StringArrayVar(&rawTagSplit, "tagSplit", nil, `Per-tag delimiter character(s) to split a multi-value tag on, as key=delimiter[,delimiter...] (repeatable), e.g. --tagSplit="team=:,-" splits the "team" tag on ':' or '-'. Parsed on the first '=' only, so delimiters may include '=' itself.`)
 
 	if err := cmd.MarkFlagRequired("role"); err != nil {
 		panic(err)
@@ -88,6 +95,28 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 	cmd.AddCommand(NewVersionCmd())
 
 	return cmd
+}
+
+// parseTagSplit parses each --tagSplit occurrence (one per tag key) into a map. It's parsed by
+// hand, splitting on only the first "=", rather than via pflag.StringToStringVar: that type
+// counts every "=" in a single occurrence to decide whether to parse it as one key=value pair
+// or several comma-separated ones, so a delimiter list containing "=" itself (a valid AWS tag
+// character) would be misparsed into a bogus extra entry instead of failing loudly. Splitting on
+// the first "=" only sidesteps that entirely, since --tagSplit is already one key per occurrence.
+func parseTagSplit(raw []string) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	tagSplit := make(map[string]string, len(raw))
+	for _, entry := range raw {
+		key, delimiters, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("--tagSplit %q must be formatted as key=delimiter[,delimiter...]", entry)
+		}
+		tagSplit[key] = delimiters
+	}
+	return tagSplit, nil
 }
 
 func validateFlagValues(flags *Flags) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -122,9 +122,9 @@ func TestNewRootCmd_TagSplit_Repeatable(t *testing.T) {
 }
 
 // A comma inside a single --tagSplit occurrence's value (used to list multiple delimiter
-// characters, e.g. "team=:,-") must survive pflag's own parsing unmangled - it does, because
-// pflag.StringToStringVar only switches to comma-as-pair-separator (CSV) parsing when a single
-// occurrence's value contains more than one "=", which never happens for one key=value pair.
+// characters, e.g. "team=:,-") is parsed as part of the delimiter list, not as a pair separator:
+// cmd.parseTagSplit splits each occurrence on the first "=" only, it never runs pflag's own
+// key=value1,key2=value2 CSV parsing.
 func TestNewRootCmd_TagSplit_CommaInValue(t *testing.T) {
 	var got *cmd.Flags
 	run := func(_ context.Context, _ *slog.Logger, f *cmd.Flags) error {
@@ -139,6 +139,38 @@ func TestNewRootCmd_TagSplit_CommaInValue(t *testing.T) {
 
 	if want := ":,-"; got.TagSplit["team"] != want {
 		t.Errorf(`TagSplit["team"] = %q, want %q`, got.TagSplit["team"], want)
+	}
+}
+
+// "=" can be used as a delimiter itself, since parseTagSplit only ever splits on the *first*
+// "=" in an occurrence - everything after it, including further "=" characters, is the
+// delimiter list verbatim.
+func TestNewRootCmd_TagSplit_EqualsSignAsDelimiter(t *testing.T) {
+	var got *cmd.Flags
+	run := func(_ context.Context, _ *slog.Logger, f *cmd.Flags) error {
+		got = f
+		return nil
+	}
+
+	_, err := execute(t, run, "--role", "my-role", "--tagSplit", "team=:,=")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := ":,="; got.TagSplit["team"] != want {
+		t.Errorf(`TagSplit["team"] = %q, want %q`, got.TagSplit["team"], want)
+	}
+}
+
+func TestNewRootCmd_TagSplit_MissingEquals(t *testing.T) {
+	run := func(context.Context, *slog.Logger, *cmd.Flags) error {
+		t.Fatal("run should not be called for a malformed --tagSplit entry")
+		return nil
+	}
+
+	_, err := execute(t, run, "--role", "my-role", "--tagSplit", "team")
+	if err == nil {
+		t.Fatal("expected an error for --tagSplit without '='")
 	}
 }
 

--- a/generator/accounts.go
+++ b/generator/accounts.go
@@ -7,15 +7,14 @@ import (
 	"strings"
 )
 
-// validTagSplitDelimiters is the subset of AWS's supported tag character set that may be
-// used as a delimiter: letters, numbers, and ". : + = @ _ / -".
+// validTagSplitDelimiters is the subset of AWS's supported tag character set that may be used
+// as a --tagSplit delimiter: letters, numbers, and ". : + = @ _ / -".
 const validTagSplitDelimiters = ".:+=@_/-"
 
 // parseDelimiters parses a --tagSplit value for one key (e.g. ":,-") into the set of
-// individual delimiter characters to split on. Delimiters are comma-separated, matching
-// pflag's own key=value1,key2=value2 convention for a single tag key's entry (a lone "," here
-// is safe: pflag.StringToStringVar only treats "," as a pair separator when a single --tagSplit
-// occurrence contains more than one "=").
+// individual delimiter characters to split on. Delimiters are comma-separated; cmd parses each
+// --tagSplit occurrence on the first "=" only (see cmd.parseTagSplit), so a delimiter list here
+// may itself contain "=" or "," without ambiguity.
 func parseDelimiters(key, raw string) (string, error) {
 	if raw == "" {
 		return "", nil
@@ -36,8 +35,14 @@ func parseDelimiters(key, raw string) (string, error) {
 }
 
 // validateTagSplit rejects any configured delimiter character outside validTagSplitDelimiters.
+// It also rejects an empty tag key: AWS tag keys can never be empty, so one showing up here is
+// never something the caller actually meant (e.g. --tagSplit="=:,-", a key accidentally left
+// blank).
 func validateTagSplit(tagSplit map[string]string) error {
 	for key, raw := range tagSplit {
+		if key == "" {
+			return fmt.Errorf("--tagSplit has an entry with an empty tag key")
+		}
 		if _, err := parseDelimiters(key, raw); err != nil {
 			return err
 		}

--- a/generator/tagsplit_test.go
+++ b/generator/tagsplit_test.go
@@ -53,6 +53,24 @@ func TestValidateTagSplit_InvalidDelimiter(t *testing.T) {
 	}
 }
 
+// "=" is a valid AWS tag character and a valid --tagSplit delimiter: cmd parses each occurrence
+// on the first "=" only (see cmd.parseTagSplit), so by the time a delimiter list reaches
+// generator, "=" is just another character - no special-casing needed here.
+func TestSplitTagValue_EqualsSignDelimiter(t *testing.T) {
+	got := splitTagValue("team", "frontend=backend", map[string]string{"team": "="})
+	want := []string{"frontend", "backend"}
+	if !equalUnordered(got, want) {
+		t.Errorf("splitTagValue() = %v, want %v", got, want)
+	}
+}
+
+func TestValidateTagSplit_EmptyTagKey(t *testing.T) {
+	err := validateTagSplit(map[string]string{"": ":,-"})
+	if err == nil {
+		t.Fatal("expected an error for an empty tag key")
+	}
+}
+
 func TestNew_InvalidTagSplitDelimiter(t *testing.T) {
 	_, err := New(t.Context(), Options{
 		RoleName: "my-role",

--- a/main.go
+++ b/main.go
@@ -35,13 +35,17 @@ func run(ctx context.Context, log *slog.Logger, flags *cmd.Flags, newGenerator n
 		return err
 	}
 
+	credentialsFile := filepath.Join(flags.CredentialPath, "credentials")
 	if err := writeCredentialsFile(flags.CredentialPath, accounts); err != nil {
 		return err
 	}
+	log.Info("wrote AWS credentials file", "path", credentialsFile)
 
+	connectionsFile := filepath.Join(flags.ConnectionsPath, "aws.spc")
 	if err := writeConnectionsFile(flags.ConnectionsPath, flags.TemplatePath, accounts); err != nil {
 		return err
 	}
+	log.Info("wrote Steampipe connections file", "path", connectionsFile)
 
 	log.Info("config files created successfully")
 	return nil


### PR DESCRIPTION
Logs now show the path of each config file written, so users can see where the credentials/connections files landed without guessing.

Also fixes --tagSplit rejecting "=" as a delimiter character (a valid AWS tag character) by parsing each --tagSplit occurrence on the first "=" only instead of relying on pflag's built-in map parsing, which misparsed values containing more than one "=".