### PR TITLE
Add source file/line to log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Log entries now include the source file and line that emitted them.
+
 ## [1.0.0] - 2026-07-21
 
 Starting with this release, `steampipe-config-generator` follows [Semantic

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -10,7 +10,7 @@ import (
 // New returns a logger writing to stderr: human-readable text for "default", structured JSON
 // for "json". Its level is read from the LOG_LEVEL env var (default info).
 func New(format string) *slog.Logger {
-	opts := &slog.HandlerOptions{Level: levelFromEnv()}
+	opts := &slog.HandlerOptions{Level: levelFromEnv(), AddSource: true}
 
 	var handler slog.Handler
 	if format == "json" {


### PR DESCRIPTION
## Summary
- Enable slog's `AddSource` option so every log entry includes the source file and line that emitted it.
- Update the changelog's Unreleased section.

## Test plan
- [x] `go test ./internal/logger/...`