### PR TITLE
docs: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-09-07
+
 ### Added
 
 - Log entries now include the source file and line that emitted them.
@@ -64,5 +66,6 @@ Versioning](#versioning). Everything below shipped since `v0.1.2`.
 See the [GitHub releases](https://github.com/unicrons/steampipe-config-generator/releases) for
 this and earlier versions.
 
-[Unreleased]: https://github.com/unicrons/steampipe-config-generator/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/unicrons/steampipe-config-generator/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/unicrons/steampipe-config-generator/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/unicrons/steampipe-config-generator/compare/v0.1.2...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Log entries now include the source file and line that emitted them.
 
+### Changed
+
+- Updated dependencies, including the AWS SDK for Go v2.
+
 ## [1.0.0] - 2026-07-21
 
 Starting with this release, `steampipe-config-generator` follows [Semantic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Upgraded to Go 1.27.1.
 - Updated dependencies.
 
 ## [1.0.0] - 2026-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Updated dependencies, including the AWS SDK for Go v2.
+- Updated dependencies.
 
 ## [1.0.0] - 2026-07-21
 


### PR DESCRIPTION
## Summary
- Rename the Unreleased section to 1.1.0 with today's date, ready to tag.

## Test plan
- N/A (changelog only)