### PR TITLE
Upgrade to Go 1.27.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12.2
+          version: v2.13.2
 
   vulncheck:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Log entries now include the source file and line that emitted them.
 
+### Changed
+
+- Upgraded to Go 1.27.1.
+
 ## [1.0.0] - 2026-07-21
 
 Starting with this release, `steampipe-config-generator` follows [Semantic

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unicrons/steampipe-config-generator
 
-go 1.26.5
+go 1.27.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.45.1


### PR DESCRIPTION
## Summary
- Bump the Go toolchain from 1.26.5 to 1.27.1 (latest stable).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`