### PR TITLE
Mark --role as required in --help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Upgraded to Go 1.27.1.
-- `--help` now marks `--role`, the only required flag, as `(required)`.
+- `--help` now marks `--role`, the only required flag, with a leading `(required)`.
 
 ## [1.0.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Upgraded to Go 1.27.1.
-- `--help` now marks `--role`, the only required flag, with a leading `(required)`.
+- `--help` now marks the required flag as `(required)`.
 
 ## [1.0.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Upgraded to Go 1.27.1.
+- `--help` now marks `--role`, the only required flag, as `(required)`.
 
 ## [1.0.0] - 2026-07-21
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 		},
 	}
 
-	cmd.Flags().StringVar(&flags.RoleName, "role", "", "AWS Role to use in AWS config credentials (required)")
+	cmd.Flags().StringVar(&flags.RoleName, "role", "", "(required) AWS Role to use in AWS config credentials")
 	cmd.Flags().StringVar(&flags.CredentialSource, "credential", "Environment", "AWS Credential source. Valid values are: Ec2InstanceMetadata, Environment, EcsContainer")
 	cmd.Flags().StringVar(&flags.CredentialPath, "path", "", "AWS Credentials file path")
 	cmd.Flags().StringVar(&flags.ConnectionsPath, "connections", "", "Steampipe AWS connections file path")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 		},
 	}
 
-	cmd.Flags().StringVar(&flags.RoleName, "role", "", "AWS Role to use in AWS config credentials")
+	cmd.Flags().StringVar(&flags.RoleName, "role", "", "AWS Role to use in AWS config credentials (required)")
 	cmd.Flags().StringVar(&flags.CredentialSource, "credential", "Environment", "AWS Credential source. Valid values are: Ec2InstanceMetadata, Environment, EcsContainer")
 	cmd.Flags().StringVar(&flags.CredentialPath, "path", "", "AWS Credentials file path")
 	cmd.Flags().StringVar(&flags.ConnectionsPath, "connections", "", "Steampipe AWS connections file path")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 		},
 	}
 
-	cmd.Flags().StringVar(&flags.RoleName, "role", "", "(required) AWS Role to use in AWS config credentials")
+	cmd.Flags().StringVar(&flags.RoleName, "role", "", "AWS Role to use in AWS config credentials (required)")
 	cmd.Flags().StringVar(&flags.CredentialSource, "credential", "Environment", "AWS Credential source. Valid values are: Ec2InstanceMetadata, Environment, EcsContainer")
 	cmd.Flags().StringVar(&flags.CredentialPath, "path", "", "AWS Credentials file path")
 	cmd.Flags().StringVar(&flags.ConnectionsPath, "connections", "", "Steampipe AWS connections file path")


### PR DESCRIPTION
## Summary
- `MarkFlagRequired` only enforces `--role` at runtime; it doesn't show up in `--help`, so it wasn't obvious which of the 11 flags were mandatory.
- Append `(required)` to `--role`'s description instead of marking the other ten as optional, since it's the only required one.

## Test plan
- [x] `go test ./...`
- [x] `go run . --help` shows `--role string   AWS Role to use in AWS config credentials (required)`