### PR TITLE
Clarify --help: dynamic defaults, input vs output paths, shorter --tagSplit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Upgraded to Go 1.27.1.
-- `--help` now marks the required flag as `(required)`.
+- `--help` now marks the required flag as `(required)`, shows the effective default for `--path`,
+  `--connections` and `--region`, clarifies that `--path` and `--connections` are output paths
+  while `--template` is an input path, and has a shorter `--tagSplit` description.
 
 ## [1.0.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Upgraded to Go 1.27.1.
-- `--help` now marks the required flag as `(required)`, shows the effective default for `--path`,
-  `--connections` and `--region`, clarifies that `--path` and `--connections` are output paths
-  while `--template` is an input path, and has a shorter `--tagSplit` description.
+- Improved `--help` flag descriptions.
 
 ## [1.0.0] - 2026-07-21
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,16 +74,16 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 
 	cmd.Flags().StringVar(&flags.RoleName, "role", "", "AWS Role to use in AWS config credentials (required)")
 	cmd.Flags().StringVar(&flags.CredentialSource, "credential", "Environment", "AWS Credential source. Valid values are: Ec2InstanceMetadata, Environment, EcsContainer")
-	cmd.Flags().StringVar(&flags.CredentialPath, "path", "", "AWS Credentials file path")
-	cmd.Flags().StringVar(&flags.ConnectionsPath, "connections", "", "Steampipe AWS connections file path")
+	cmd.Flags().StringVar(&flags.CredentialPath, "path", "", "Path where the AWS credentials file is written (default: ~/.aws/)")
+	cmd.Flags().StringVar(&flags.ConnectionsPath, "connections", "", "Path where the Steampipe AWS connections file is written (default: ~/.steampipe/config/)")
 	cmd.Flags().StringVar(&flags.ImportSchema, "schema", "enabled", "AWS Connection import schema. Valid values are: enabled, disabled")
-	cmd.Flags().StringVar(&flags.DefaultRegion, "region", "", "AWS Connection default region")
+	cmd.Flags().StringVar(&flags.DefaultRegion, "region", "", "AWS Connection default region (default: $AWS_REGION, or us-east-1)")
 	cmd.Flags().StringVar(&targetRegions, "regions", "all", "AWS Connection target regions")
 	cmd.Flags().StringVar(&flags.AssumeRoleArn, "assume", "", "AWS Role to assume for getting Organization accounts")
-	cmd.Flags().StringVar(&flags.TemplatePath, "template", "", "Custom connections template path")
+	cmd.Flags().StringVar(&flags.TemplatePath, "template", "", "Path to a custom template file used to render the connections file")
 	cmd.Flags().StringVar(&flags.LogFormat, "log", "default", "Log format: default, json")
 	cmd.Flags().StringVar(&skipOUs, "skipOUs", "", "AWS OU IDs to skip from account connections")
-	cmd.Flags().StringArrayVar(&rawTagSplit, "tagSplit", nil, `Per-tag delimiter character(s) to split a multi-value tag on, as key=delimiter[,delimiter...] (repeatable), e.g. --tagSplit="team=:,-" splits the "team" tag on ':' or '-'. Parsed on the first '=' only, so delimiters may include '=' itself.`)
+	cmd.Flags().StringArrayVar(&rawTagSplit, "tagSplit", nil, `Split a multi-value tag into individual values, as key=delimiter[,delimiter...] (repeatable). E.g. --tagSplit="team=:,-" splits the "team" tag on ':' or '-'. See README for details.`)
 
 	if err := cmd.MarkFlagRequired("role"); err != nil {
 		panic(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,7 +83,7 @@ func NewRootCmd(run func(ctx context.Context, log *slog.Logger, flags *Flags) er
 	cmd.Flags().StringVar(&flags.TemplatePath, "template", "", "Path to a custom template file used to render the connections file")
 	cmd.Flags().StringVar(&flags.LogFormat, "log", "default", "Log format: default, json")
 	cmd.Flags().StringVar(&skipOUs, "skipOUs", "", "AWS OU IDs to skip from account connections")
-	cmd.Flags().StringArrayVar(&rawTagSplit, "tagSplit", nil, `Split a multi-value tag into individual values, as key=delimiter[,delimiter...] (repeatable). E.g. --tagSplit="team=:,-" splits the "team" tag on ':' or '-'. See README for details.`)
+	cmd.Flags().StringArrayVar(&rawTagSplit, "tagSplit", nil, `Split a multi-value tag into individual values, as key=delimiter[,delimiter...] (repeatable). See README for details.`)
 
 	if err := cmd.MarkFlagRequired("role"); err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary
- `--path`, `--connections` and `--region` compute their defaults at runtime (home directory, `$AWS_REGION`), so pflag couldn't show them in `--help`; documented them by hand.
- `--path`, `--connections` and `--template` all read as generic "file path" descriptions with no hint of direction; now says which are written and which is read.
- Shortened `--tagSplit`'s description, moving the parsing edge case (first `=` only) to the README.

(Follow-up to #31 — this commit was pushed to that branch after it had already merged, so it never made it into main.)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run . --help` reviewed